### PR TITLE
Fix for a "Conditional jump or move depends on uninitialised value(s)"

### DIFF
--- a/include/zstd_stream_wrapper.hpp
+++ b/include/zstd_stream_wrapper.hpp
@@ -47,9 +47,8 @@ class zstd_stream_wrapper : public stream_wrapper {
 	    this->cctx = ZSTD_createCCtx();
 	    if (this->cctx == NULL) throw zstdException("ZSTD_createCCtx() failed!");
 	    this->ret = ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, level);
+	    if (ZSTD_isError(this->ret)) throw zstdException(this->ret);
 	}
-	if (ZSTD_isError(this->ret)) throw zstdException(this->ret);
-
     }
 
     ~zstd_stream_wrapper() {


### PR DESCRIPTION
problem detected by valgrind

==27187== Memcheck, a memory error detector
==27187== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al. ==27187== Using Valgrind-3.23.0 and LibVEX; rerun with -h for copyright info ==27187== Command: ./testIO9
==27187==
==27187== Conditional jump or move depends on uninitialised value(s)
==27187==    at 0x116F4A: UnknownInlinedFun (zstd_stream_wrapper.hpp:54)
==27187==    by 0x116F4A: bxz::init_stream(bxz::Compression const&, bool, int, std::unique_ptr<bxz::detail::stream_wrapper, std::default_delete<bxz::detail::stream_wrapper> >*) (compression_types.hpp:62)
==27187==    by 0x1173B5: UnknownInlinedFun (compression_types.hpp:70)
==27187==    by 0x1173B5: bxz::istreambuf::underflow() (bxzstr.hpp:115)
==27187==    by 0x4B01FF1: std::istream::getline(char*, long, char) (in /usr/lib64/libstdc++.so.6.0.33)
==27187==    by 0x48C5660: HepMC3::ReaderAsciiHepMC2::read_event(HepMC3::GenEvent&) (ReaderAsciiHepMC2.cc:99)
==27187==    by 0x1111C1: UnknownInlinedFun (ReaderGZ.h:55)
==27187==    by 0x1111C1: main (testIO9.cc:71)